### PR TITLE
require a higher version of nokogiri for rails 4.2 compatibility

### DIFF
--- a/sports_data_api.gemspec
+++ b/sports_data_api.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = %w{lib}
   gem.version       = SportsDataApi::VERSION
 
-  gem.add_dependency 'nokogiri', '~> 1.5.5'
+  gem.add_dependency 'nokogiri', '>= 1.5.0'
   gem.add_dependency 'rest-client', '~> 1.6.7'
   gem.add_dependency 'multi_json', '~> 1.10.1'
 


### PR DESCRIPTION
When trying to upgrade to rails 4.2, actionmailer 4.2 requires nokogiri ~> 1.6.0.

rails (= 4.2.0) ruby depends on
      actionmailer (= 4.2.0) ruby depends on
        rails-dom-testing (>= 1.0.5, ~> 1.0) ruby depends on
          nokogiri (~> 1.6.0) ruby

    sports_data_api (>= 0) ruby depends on
      nokogiri (1.5.5)