### PR TITLE
lock tins for ruby 1.9.3

### DIFF
--- a/sports_data_api.gemspec
+++ b/sports_data_api.gemspec
@@ -30,5 +30,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'webmock', '~> 1.9.0'
   gem.add_development_dependency 'faker', '~> 1.1.2'
   gem.add_development_dependency 'simplecov', '~> 0.7.1'
+  gem.add_development_dependency 'tins', '~> 0.8' if RUBY_VERSION == '1.9.3'
   gem.add_development_dependency 'coveralls'
 end


### PR DESCRIPTION
lock tins specifically for 1.89.3, no need to touch bundler
