### PR TITLE
coveralls require a version of tins incompatible with ruby 1.9.3

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,10 +1,19 @@
 require 'simplecov'
-require 'coveralls'
 require 'pry'
-SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
-  Coveralls::SimpleCov::Formatter,
-  SimpleCov::Formatter::HTMLFormatter
-]
+
+if RUBY_VERSION.to_i >= 2
+  require 'coveralls'
+
+  SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
+    Coveralls::SimpleCov::Formatter,
+    SimpleCov::Formatter::HTMLFormatter
+  ]
+else
+  SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
+    SimpleCov::Formatter::HTMLFormatter
+  ]
+end
+
 SimpleCov.start do
   add_filter "/spec/"
 end

--- a/sports_data_api.gemspec
+++ b/sports_data_api.gemspec
@@ -30,5 +30,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'webmock', '~> 1.9.0'
   gem.add_development_dependency 'faker', '~> 1.1.2'
   gem.add_development_dependency 'simplecov', '~> 0.7.1'
-  gem.add_development_dependency 'coveralls'
+  gem.add_development_dependency 'coveralls' if RUBY_VERSION.to_i >= 2
 end


### PR DESCRIPTION
disable coverall formatters for 1.9.3
