### PR TITLE
Switch to Code Climate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,6 @@ rvm:
   - 2.1
   - 2.2
   - ruby-head
+addons:
+  code_climate:
+    repo_token: a3efbc440cb5027fc10a3cfa845aab934cf8c48c27fa0b2ff34855933245aca1

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# SportsDataApi [![Build Status](https://travis-ci.org/RLovelett/sports_data_api.png?branch=master)](https://travis-ci.org/RLovelett/sports_data_api) [![Coverage Status](https://coveralls.io/repos/RLovelett/sports_data_api/badge.png?branch=master)](https://coveralls.io/r/RLovelett/sports_data_api?branch=master) [![Gem Version](https://badge.fury.io/rb/sports_data_api.svg)](http://badge.fury.io/rb/sports_data_api) [![Code Climate](https://codeclimate.com/github/RLovelett/sports_data_api/badges/gpa.svg)](https://codeclimate.com/github/RLovelett/sports_data_api)
+# SportsDataApi [![Build Status](https://travis-ci.org/RLovelett/sports_data_api.png?branch=master)](https://travis-ci.org/RLovelett/sports_data_api) [![Gem Version](https://badge.fury.io/rb/sports_data_api.svg)](http://badge.fury.io/rb/sports_data_api) [![Code Climate](https://codeclimate.com/github/RLovelett/sports_data_api/badges/gpa.svg)](https://codeclimate.com/github/RLovelett/sports_data_api)
 
 SportsDataApi is an attempt to make a Ruby interface to the
 [SportsData](http://www.sportsdatallc.com/) API. The goal is to

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 require 'simplecov'
 require 'coveralls'
 require 'pry'
+require 'codeclimate-test-reporter'
 SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
   Coveralls::SimpleCov::Formatter,
   SimpleCov::Formatter::HTMLFormatter
@@ -8,6 +9,7 @@ SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
 SimpleCov.start do
   add_filter "/spec/"
 end
+CodeClimate::TestReporter.start
 
 # Previous content of test helper now starts here
 require "sports_data_api"
@@ -46,6 +48,11 @@ VCR.configure do |c|
   c.hook_into :webmock
   c.preserve_exact_body_bytes { true }
   c.configure_rspec_metadata!
+
+  # VCR will prevent the codeclimate-test-reporter from reporting results to
+  # codeclimate.com. Configure VCR to ignore the codeclimate.com hostname to
+  # ensure codeclimate-test-reporter can post coverage results.
+  c.ignore_hosts 'codeclimate.com'
 
   ##
   # Filter the real API key so that it does not make its way into the VCR cassette

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,11 +1,6 @@
 require 'simplecov'
-require 'coveralls'
 require 'pry'
 require 'codeclimate-test-reporter'
-SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
-  Coveralls::SimpleCov::Formatter,
-  SimpleCov::Formatter::HTMLFormatter
-]
 SimpleCov.start do
   add_filter "/spec/"
 end

--- a/sports_data_api.gemspec
+++ b/sports_data_api.gemspec
@@ -29,6 +29,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'vcr', '~> 2.4.0'
   gem.add_development_dependency 'webmock', '~> 1.9.0'
   gem.add_development_dependency 'faker', '~> 1.1.2'
-  gem.add_development_dependency 'simplecov', '~> 0.7.1'
+  gem.add_development_dependency 'simplecov', '~> 0.11.0'
   gem.add_development_dependency 'codeclimate-test-reporter'
 end

--- a/sports_data_api.gemspec
+++ b/sports_data_api.gemspec
@@ -30,6 +30,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'webmock', '~> 1.9.0'
   gem.add_development_dependency 'faker', '~> 1.1.2'
   gem.add_development_dependency 'simplecov', '~> 0.7.1'
-  gem.add_development_dependency 'coveralls'
   gem.add_development_dependency 'codeclimate-test-reporter'
 end

--- a/sports_data_api.gemspec
+++ b/sports_data_api.gemspec
@@ -31,4 +31,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'faker', '~> 1.1.2'
   gem.add_development_dependency 'simplecov', '~> 0.7.1'
   gem.add_development_dependency 'coveralls'
+  gem.add_development_dependency 'codeclimate-test-reporter'
 end


### PR DESCRIPTION
Coveralls seems to be a duplicate of what Code Climate provides. So I'm just streamlining to use only one.

The other thing I did was update [SimpleCov](https://github.com/colszowka/simplecov) for local code coverage.