### PR TITLE
Add back support for 1.9.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: ruby
 before_install: gem install bundler && bundler -v
 rvm:
+  - 1.9.3
   - 2.0.0
   - 2.1
   - 2.2


### PR DESCRIPTION
#50 dropped support for Ruby 1.9.3 mostly because it was failing the Travis builds and partly because it was no longer receiving patches.

Now that the Travis builds are back under control there is no reason to drop support for it anymore. So I'll add it back.