### PR TITLE
increase rest-client version to non-vulnerable one

### DIFF
--- a/sports_data_api.gemspec
+++ b/sports_data_api.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.version       = SportsDataApi::VERSION
 
   gem.add_dependency 'nokogiri', '>= 1.5.0'
-  gem.add_dependency 'rest-client', '~> 1.6.7'
+  gem.add_dependency 'rest-client', '>= 1.8.0'
   gem.add_dependency 'multi_json', '~> 1.11.0'
 
   gem.add_development_dependency 'rake', '~> 10.0.4'


### PR DESCRIPTION
two vulnerability has been fixed since rest-client 1.8

Sources:
https://github.com/rest-client/rest-client/issues/349
http://www.osvdb.org/show/osvdb/117461
https://github.com/rest-client/rest-client/issues/369

Found using Gemnasium
https://gemnasium.com/mathieujobin/sports_data_api/alerts
